### PR TITLE
ci(release): simplify build command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v1
         with:
-          command: ${{ matrix.platform.command }}
+          command: build
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
           strip: true


### PR DESCRIPTION
This commit replaces the platform-specific command with a simple 'build' command in the GitHub Actions release workflow. The change makes the workflow more maintainable since we no longer need to manage different commands per platform, while still achieving the same build outcome through the default behavior of the action.