### PR TITLE
docs(readme): update installation instructions and remove docs.rs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/aic)](https://crates.io/crates/aic)
-![docs.rs](https://img.shields.io/docsrs/aic)
+
 
 A CLI tool that uses AI to generate meaningful commit messages by analyzing your staged Git changes.
 
@@ -16,7 +16,7 @@ A CLI tool that uses AI to generate meaningful commit messages by analyzing your
 ## Installation
 
 ```bash
-cargo install --git https://github.com/shenxiangzhuang/aic.git
+cargo install aic
 ```
 
 ## Quick Start


### PR DESCRIPTION
This commit:
- Updates the installation command to use crates.io instead of git
- Removes the docs.rs badge since it wasn't working properly
- Maintains all other documentation content and structure

The changes make the installation process simpler for users and remove a non-functional badge.