### PR TITLE
feat(ci): add code coverage workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,22 @@ jobs:
     
     - name: Build
       run: cargo build --verbose 
+
+
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: shenxiangzhuang/aic

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/aic)](https://crates.io/crates/aic)
-
+[![codecov](https://codecov.io/gh/shenxiangzhuang/aic/graph/badge.svg?token=Ekvrf0TzJa)](https://codecov.io/gh/shenxiangzhuang/aic)
 
 A CLI tool that uses AI to generate meaningful commit messages by analyzing your staged Git changes.
 


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to generate and upload code coverage reports to Codecov. The coverage job runs on Ubuntu and:
- Installs Rust stable
- Sets up cargo-llvm-cov
- Generates coverage reports in lcov format
- Uploads reports to Codecov using a secret token

The change helps track test coverage metrics and maintain code quality standards.