### PR TITLE
fix(ui): properly truncate prompts by character count instead of bytes

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -59,14 +59,23 @@ pub fn print_config_table(config: &Config) {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use std::env;
+    use tempfile::TempDir;
 
-    // Helper function for creating test config
-    fn create_test_config() -> Config {
-        let mut config = Config::default();
-        config.set("api_token", Some("test_token_123".to_string())).unwrap();
-        config.set("api_base_url", Some("https://api.example.com".to_string())).unwrap();
-        config.set("model", Some("gpt-4".to_string())).unwrap();
-        config
+    // Helper function to create a test environment
+    fn setup_test_env() -> (TempDir, Config) {
+        // Create a temporary directory
+        let temp_dir = TempDir::new()
+            .expect("Failed to create temp directory");
+        let config_dir = temp_dir.path().join(".config").join("aic");
+        std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
+
+        // Set the HOME environment variable to the temporary directory
+        env::set_var("HOME", temp_dir.path());
+
+        // Create a new config instance
+        let config = Config::default();
+        (temp_dir, config)
     }
 
     #[test]
@@ -77,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_token_masking() {
-        let mut config = create_test_config();
+        let (_temp_dir, mut config) = setup_test_env();
         
         // Test long token
         config.set("api_token", Some("abcd1234567890".to_string())).unwrap();
@@ -94,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_english_prompts() {
-        let mut config = create_test_config();
+        let (_temp_dir, mut config) = setup_test_env();
 
         // Test short prompt (no truncation)
         config.set("system_prompt", Some("Short msg".to_string())).unwrap();
@@ -129,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_chinese_display() {
-        let mut config = create_test_config();
+        let (_temp_dir, mut config) = setup_test_env();
         
         // Test simple Chinese prompt
         config.set("system_prompt", Some("编写提交信息".to_string())).unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -36,8 +36,8 @@ pub fn print_config_table(config: &Config) {
 
     // System prompt (truncated if too long)
     let system_prompt = config.get_system_prompt();
-    let display_system_prompt = if system_prompt.len() > 36 {
-        format!("{}...", &system_prompt[0..33])
+    let display_system_prompt = if system_prompt.chars().count() > 12 {
+        format!("{}...", system_prompt.chars().take(12).collect::<String>())
     } else {
         system_prompt.to_string()
     };
@@ -45,8 +45,8 @@ pub fn print_config_table(config: &Config) {
 
     // User prompt (truncated if too long)
     let user_prompt = config.get_user_prompt();
-    let display_user_prompt = if user_prompt.len() > 36 {
-        format!("{}...", &user_prompt[0..33])
+    let display_user_prompt = if user_prompt.chars().count() > 12 {
+        format!("{}...", user_prompt.chars().take(12).collect::<String>())
     } else {
         user_prompt.to_string()
     };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -54,3 +54,97 @@ pub fn print_config_table(config: &Config) {
 
     table.printstd();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    // Helper function for creating test config
+    fn create_test_config() -> Config {
+        let mut config = Config::default();
+        config.set("api_token", Some("test_token_123".to_string())).unwrap();
+        config.set("api_base_url", Some("https://api.example.com".to_string())).unwrap();
+        config.set("model", Some("gpt-4".to_string())).unwrap();
+        config
+    }
+
+    #[test]
+    fn test_print_header() {
+        // Verify header printing doesn't panic
+        print_header();
+    }
+
+    #[test]
+    fn test_token_masking() {
+        let mut config = create_test_config();
+        
+        // Test long token
+        config.set("api_token", Some("abcd1234567890".to_string())).unwrap();
+        print_config_table(&config);
+        
+        // Test short token
+        config.set("api_token", Some("abc".to_string())).unwrap();
+        print_config_table(&config);
+        
+        // Test no token
+        config.set("api_token", None).unwrap();
+        print_config_table(&config);
+    }
+
+    #[test]
+    fn test_english_prompts() {
+        let mut config = create_test_config();
+
+        // Test short prompt (no truncation)
+        config.set("system_prompt", Some("Short msg".to_string())).unwrap();
+        config.set("user_prompt", Some("Brief prompt".to_string())).unwrap();
+        print_config_table(&config);
+
+        // Test exact length prompt (12 chars)
+        config.set("system_prompt", Some("Exactly12Chars".to_string())).unwrap();
+        print_config_table(&config);
+
+        // Test long prompt (with truncation)
+        config.set("system_prompt", Some("This is a very long prompt that should be truncated".to_string())).unwrap();
+        config.set("user_prompt", Some("Another long prompt that needs truncation".to_string())).unwrap();
+        
+        let system_prompt = config.get_system_prompt();
+        let display_system_prompt = if system_prompt.chars().count() > 12 {
+            format!("{}...", system_prompt.chars().take(12).collect::<String>())
+        } else {
+            system_prompt.to_string()
+        };
+
+        let user_prompt = config.get_user_prompt();
+        let display_user_prompt = if user_prompt.chars().count() > 12 {
+            format!("{}...", user_prompt.chars().take(12).collect::<String>())
+        } else {
+            user_prompt.to_string()
+        };
+
+        assert_eq!(display_system_prompt, "This is a ve...");
+        assert_eq!(display_user_prompt, "Another long...");
+    }
+
+    #[test]
+    fn test_chinese_display() {
+        let mut config = create_test_config();
+        
+        // Test simple Chinese prompt
+        config.set("system_prompt", Some("编写提交信息".to_string())).unwrap();
+        config.set("user_prompt", Some("生成提交说明".to_string())).unwrap();
+        
+        let system_prompt = config.get_system_prompt();
+        let display_system_prompt = if system_prompt.chars().count() > 12 {
+            format!("{}...", system_prompt.chars().take(12).collect::<String>())
+        } else {
+            system_prompt.to_string()
+        };
+
+        // Verify Chinese characters are displayed correctly (no truncation needed)
+        assert_eq!(display_system_prompt, "编写提交信息");
+        
+        print_config_table(&config);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,8 +65,7 @@ mod tests {
     // Helper function to create a test environment
     fn setup_test_env() -> (TempDir, Config) {
         // Create a temporary directory
-        let temp_dir = TempDir::new()
-            .expect("Failed to create temp directory");
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let config_dir = temp_dir.path().join(".config").join("aic");
         std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
 
@@ -87,15 +86,17 @@ mod tests {
     #[test]
     fn test_token_masking() {
         let (_temp_dir, mut config) = setup_test_env();
-        
+
         // Test long token
-        config.set("api_token", Some("abcd1234567890".to_string())).unwrap();
+        config
+            .set("api_token", Some("abcd1234567890".to_string()))
+            .unwrap();
         print_config_table(&config);
-        
+
         // Test short token
         config.set("api_token", Some("abc".to_string())).unwrap();
         print_config_table(&config);
-        
+
         // Test no token
         config.set("api_token", None).unwrap();
         print_config_table(&config);
@@ -106,18 +107,34 @@ mod tests {
         let (_temp_dir, mut config) = setup_test_env();
 
         // Test short prompt (no truncation)
-        config.set("system_prompt", Some("Short msg".to_string())).unwrap();
-        config.set("user_prompt", Some("Brief prompt".to_string())).unwrap();
+        config
+            .set("system_prompt", Some("Short msg".to_string()))
+            .unwrap();
+        config
+            .set("user_prompt", Some("Brief prompt".to_string()))
+            .unwrap();
         print_config_table(&config);
 
         // Test exact length prompt (12 chars)
-        config.set("system_prompt", Some("Exactly12Chars".to_string())).unwrap();
+        config
+            .set("system_prompt", Some("Exactly12Chars".to_string()))
+            .unwrap();
         print_config_table(&config);
 
         // Test long prompt (with truncation)
-        config.set("system_prompt", Some("This is a very long prompt that should be truncated".to_string())).unwrap();
-        config.set("user_prompt", Some("Another long prompt that needs truncation".to_string())).unwrap();
-        
+        config
+            .set(
+                "system_prompt",
+                Some("This is a very long prompt that should be truncated".to_string()),
+            )
+            .unwrap();
+        config
+            .set(
+                "user_prompt",
+                Some("Another long prompt that needs truncation".to_string()),
+            )
+            .unwrap();
+
         let system_prompt = config.get_system_prompt();
         let display_system_prompt = if system_prompt.chars().count() > 12 {
             format!("{}...", system_prompt.chars().take(12).collect::<String>())
@@ -139,11 +156,15 @@ mod tests {
     #[test]
     fn test_chinese_display() {
         let (_temp_dir, mut config) = setup_test_env();
-        
+
         // Test simple Chinese prompt
-        config.set("system_prompt", Some("编写提交信息".to_string())).unwrap();
-        config.set("user_prompt", Some("生成提交说明".to_string())).unwrap();
-        
+        config
+            .set("system_prompt", Some("编写提交信息".to_string()))
+            .unwrap();
+        config
+            .set("user_prompt", Some("生成提交说明".to_string()))
+            .unwrap();
+
         let system_prompt = config.get_system_prompt();
         let display_system_prompt = if system_prompt.chars().count() > 12 {
             format!("{}...", system_prompt.chars().take(12).collect::<String>())
@@ -153,7 +174,7 @@ mod tests {
 
         // Verify Chinese characters are displayed correctly (no truncation needed)
         assert_eq!(display_system_prompt, "编写提交信息");
-        
+
         print_config_table(&config);
     }
 }


### PR DESCRIPTION
This commit changes how prompts are truncated in the config table display. Previously we used byte length which could cut multi-byte UTF-8 characters in the middle. Now we properly count characters using chars().count() and truncate after 12 characters.

The change ensures proper display of Unicode prompts and provides more consistent truncation behavior across different languages and character sets.