### PR TITLE
chore: bump version to 0.1.2 and update metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aic"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "aic"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "AI-powered commit message generation CLI tool"
 authors = ["Mathew Shen <datahonor@gmail.com>"]
 repository = "https://github.com/shenxiangzhuang/aic"
+homepage = "https://github.com/shenxiangzhuang/aic"
 readme = "README.md"
 license = "MIT"
-keywords = ["AI", "LLM", "Git", "Commit"]
+keywords = ["ai", "llm", "git", "commit", "cli"]
+categories = ["command-line-utilities"]
 
 
 [dependencies]


### PR DESCRIPTION
This commit updates the package version from 0.1.1 to 0.1.2 in both Cargo.toml and Cargo.lock. It also enhances the project metadata by:
- Adding homepage URL
- Standardizing keywords to lowercase
- Adding 'command-line-utilities' category

These changes improve package discoverability and maintain consistency with crates.io requirements.