### PR TITLE
fix(config): split default prompt into system and user prompts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,9 +73,13 @@ pub enum ConfigCommands {
         #[arg(long, help = "Model to use for generating commit messages")]
         model: Option<String>,
 
-        /// Default system prompt for commit message generation
-        #[arg(long, help = "Default system prompt for commit message generation")]
-        default_prompt: Option<String>,
+        /// System prompt for commit message generation
+        #[arg(long, help = "System prompt for commit message generation")]
+        system_prompt: Option<String>,
+
+        /// User prompt for commit message generation
+        #[arg(long, help = "User prompt for commit message generation")]
+        user_prompt: Option<String>,
     },
 
     /// List all configuration values
@@ -135,6 +139,10 @@ mod tests {
             "gpt-4",
             "--api-base-url",
             "https://api.example.com",
+            "--system-prompt",
+            "Test system prompt",
+            "--user-prompt",
+            "Test user prompt"
         ]);
 
         match args.command {
@@ -142,12 +150,14 @@ mod tests {
                 api_token,
                 model,
                 api_base_url,
-                default_prompt,
+                system_prompt,
+                user_prompt,
             })) => {
                 assert_eq!(api_token, Some("test-token".to_string()));
                 assert_eq!(model, Some("gpt-4".to_string()));
                 assert_eq!(api_base_url, Some("https://api.example.com".to_string()));
-                assert!(default_prompt.is_none());
+                assert_eq!(system_prompt, Some("Test system prompt".to_string()));
+                assert_eq!(user_prompt, Some("Test user prompt".to_string()));
             }
             _ => panic!("Expected Config Setup command"),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,7 +142,7 @@ mod tests {
             "--system-prompt",
             "Test system prompt",
             "--user-prompt",
-            "Test user prompt"
+            "Test user prompt",
         ]);
 
         match args.command {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -246,7 +246,8 @@ pub async fn handle_config_command(config_cmd: &ConfigCommands) -> Result<()> {
             api_token,
             api_base_url,
             model,
-            default_prompt,
+            system_prompt,
+            user_prompt,
         } => {
             println!("{}", "⚙️  Updating configuration...".blue());
 
@@ -278,9 +279,15 @@ pub async fn handle_config_command(config_cmd: &ConfigCommands) -> Result<()> {
                 changes += 1;
             }
 
-            if let Some(prompt) = default_prompt {
-                config.set("default_prompt", Some(prompt.clone()))?;
-                println!("✓ Set default_prompt to: {}", prompt);
+            if let Some(system_prompt) = system_prompt {
+                config.set("system_prompt", Some(system_prompt.clone()))?;
+                println!("✓ Set system_prompt to: {}", system_prompt);
+                changes += 1;
+            }
+
+            if let Some(users_prompt) = user_prompt {
+                config.set("user_prompt", Some(users_prompt.clone()))?;
+                println!("✓ Set user_prompt to: {}", users_prompt);
                 changes += 1;
             }
 


### PR DESCRIPTION
Related to #20 

This commit replaces the single `default_prompt` configuration option with separate `system_prompt` and `user_prompt` options. The change allows for more granular control over the commit message generation process by distinguishing between the system's instructions and the user's specific requirements.

The modification includes:
- CLI argument changes
- Configuration handling updates
- Test case adjustments to verify the new behavior