### PR TITLE
refactor(commands): simplify temporary file handling with tempfile crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ uuid = { version = "1.7", features = ["v4"] }
 prettytable-rs = "0.10"
 dirs = "6.0.0"
 reqwest = { version = "0.12.15", features = ["json"] }
+tempfile = "3.19.1"
 
 [dev-dependencies]
 wiremock = "0.6.3"
-tempfile = "3.19.1"
 
 
 [profile.release]


### PR DESCRIPTION
This commit replaces the manual temporary file creation and cleanup in the commit message editor with the `tempfile` crate's Builder pattern. The tempfile crate provides more robust and safer temporary file handling with automatic cleanup.

- Moved tempfile from dev-dependencies to main dependencies since it's now used in production code
- Replaced custom TempFileGuard with tempfile's Builder and TempDir
- Simplified file cleanup by leveraging tempfile's automatic deletion

The change makes the code more maintainable and reduces the risk of temporary file leaks while maintaining the same functionality.