### PR TITLE
fix: update OpenAI API base URL to include /v1 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Output:
 ⚙️  Current Configuration:
 ┌───────────────┬──────────────────────────────────────┐
 │ api_token     │ your•••••                            │
-│ api_base_url  │ https://api.openai.com/v1               │
+│ api_base_url  │ https://api.openai.com/v1            │
 │ model         │ gpt-3.5-turbo                        │
 │ system_prompt │ You are an expert at writing...      │
 │ user_prompt   │ Here is the git diff of the staged...│

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo install aic
 
 ```bash
 # For OpenAI
-aic config setup --api-token your_openai_token --api-base-url https://api.openai.com --model gpt-3.5-turbo
+aic config setup --api-token your_openai_token --api-base-url https://api.openai.com/v1 --model gpt-3.5-turbo
 
 # For DeepSeek
 aic config setup --api-token your_deepseek_token --api-base-url https://api.deepseek.com --model deepseek-chat
@@ -37,7 +37,7 @@ Output:
 ```bash
 ⚙️  Updating configuration...
 ✓ Set api_token to: your•••••
-✓ Set api_base_url to: https://api.openai.com
+✓ Set api_base_url to: https://api.openai.com/v1
 ✓ Set model to: gpt-3.5-turbo
 🎉 Configuration updated successfully!
 ```
@@ -54,7 +54,7 @@ Output:
 ⚙️  Current Configuration:
 ┌───────────────┬──────────────────────────────────────┐
 │ api_token     │ your•••••                            │
-│ api_base_url  │ https://api.openai.com               │
+│ api_base_url  │ https://api.openai.com/v1               │
 │ model         │ gpt-3.5-turbo                        │
 │ system_prompt │ You are an expert at writing...      │
 │ user_prompt   │ Here is the git diff of the staged...│
@@ -74,7 +74,7 @@ Output:
 
 ```
 🔍 Testing API connection...
-🌐 API Base URL: https://api.openai.com
+🌐 API Base URL: https://api.openai.com/v1
 🤖 Model: gpt-3.5-turbo
 ✅ API connection successful!
 ✨ Configuration is working correctly.
@@ -97,6 +97,7 @@ aic
 ```
 
 Example output:
+
 ```
 ╭─────────────────────────────────────╮
 │     AI Commit Message Generator     │
@@ -137,7 +138,7 @@ aic -ap
 # Generate, commit, and push automatically
 aic -cp
 
-# Stage all changes, commit, and push automatically 
+# Stage all changes, commit, and push automatically
 aic -acp
 
 # Test API connection
@@ -150,7 +151,7 @@ aic ping
 
 ```bash
 # Quick setup
-aic config setup --api-token <TOKEN> --api-base-url https://api.openai.com --model gpt-4-turbo
+aic config setup --api-token <TOKEN> --api-base-url https://api.openai.com/v1 --model gpt-4-turbo
 
 # View current settings
 aic config list
@@ -173,6 +174,7 @@ You can also create a project-specific `.aic.toml` file in your repository root.
 #### Global Configuration
 
 The global configuration is stored in TOML format at:
+
 - Linux/macOS: `~/.config/aic/config.toml`
 - Windows: `%APPDATA%\aic\config.toml`
 
@@ -180,9 +182,9 @@ Example `config.toml`:
 
 ```toml
 api_token = "your_api_token_here"
-api_base_url = "https://api.openai.com"
+api_base_url = "https://api.openai.com/v1"
 model = "gpt-3.5-turbo"
-system_prompt = """You are an expert at writing clear and concise commit messages. 
+system_prompt = """You are an expert at writing clear and concise commit messages.
 Follow these rules strictly:
 
 1. Start with a type: feat, fix, docs, style, refactor, perf, test, build, ci, chore, or revert
@@ -226,7 +228,7 @@ In addition to global settings, you can create a project-specific configuration 
 aic config show
 ```
 
-1. Create a `.aic.toml` file in your Git repository root 
+1. Create a `.aic.toml` file in your Git repository root
 2. Project settings will override global settings when running `aic` in that repository
 3. The search for project config will stop at the Git repository root (directory with `.git` folder)
 
@@ -238,14 +240,14 @@ Example `.aic.toml`:
 
 # API settings
 api_token = "your_api_token_here"  # Only add if different from global config
-api_base_url = "https://api.openai.com"
+api_base_url = "https://api.openai.com/v1"
 model = "gpt-4-turbo"  # Use a different model for this project
 
 # Customized prompts for project-specific commit conventions
 system_prompt = """You are a commit message expert for our project.
 Use our project conventions:
 1. feat: for new features
-2. fix: for bug fixes 
+2. fix: for bug fixes
 3. docs: for documentation
 4. refactor: for code changes that neither fix bugs nor add features
 5. style: for changes that do not affect the meaning of the code

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -78,7 +78,7 @@ pub async fn generate_commit(
 
     // Format git commit command for display
     let escaped_message = commit_message.replace("\"", "\\\"");
-    let commit_command = format!("git commit -m \"{}\"", escaped_message);
+    let commit_command = format!("git commit -m \"{escaped_message}\"");
 
     // Only print the command, not the message again
     println!("{}", "📋 Commit command:".green().bold());
@@ -114,7 +114,7 @@ fn execute_commit(commit_message: &str) -> Result<()> {
     } else {
         println!("{}", "❌ Git commit command failed:".red().bold());
         if let Some(code) = status.code() {
-            println!("Exit code: {}", code);
+            println!("Exit code: {code}");
         }
     }
 
@@ -169,7 +169,7 @@ fn handle_commit_options(commit_message: &str, auto_push: bool) -> Result<()> {
         } else {
             println!("{}", "❌ Git commit command failed:".red().bold());
             if let Some(code) = status.code() {
-                println!("Exit code: {}", code);
+                println!("Exit code: {code}");
             }
         }
     } else if input.starts_with('n') {
@@ -216,7 +216,7 @@ fn edit_commit_message(commit_message: &str) -> Result<String> {
     let edit_status = Command::new(&editor)
         .arg(&tmp_file_path)
         .status()
-        .context(format!("Failed to open editor ({})", editor))?;
+        .context(format!("Failed to open editor ({editor})"))?;
 
     if !edit_status.success() {
         return Err(anyhow::anyhow!("Editor exited with non-zero status"));
@@ -251,7 +251,7 @@ async fn handle_config_command(config_cmd: &ConfigCommands) -> Result<()> {
             config.set(key, value.clone())?;
 
             if let Some(val) = value {
-                println!("✓ Set {} to: {}", key.bright_blue(), val);
+                println!("✓ Set {} to: {val}", key.bright_blue());
             } else {
                 println!("✓ Unset {}", key.bright_blue());
             }
@@ -277,31 +277,31 @@ async fn handle_config_command(config_cmd: &ConfigCommands) -> Result<()> {
                 } else {
                     "•••••••".to_string()
                 };
-                println!("✓ Set api_token to: {}", masked_token);
+                println!("✓ Set api_token to: {masked_token}");
                 changes += 1;
             }
 
             if let Some(url) = api_base_url {
                 config.set("api_base_url", Some(url.clone()))?;
-                println!("✓ Set api_base_url to: {}", url);
+                println!("✓ Set api_base_url to: {url}");
                 changes += 1;
             }
 
             if let Some(model_name) = model {
                 config.set("model", Some(model_name.clone()))?;
-                println!("✓ Set model to: {}", model_name);
+                println!("✓ Set model to: {model_name}");
                 changes += 1;
             }
 
             if let Some(system_prompt) = system_prompt {
                 config.set("system_prompt", Some(system_prompt.clone()))?;
-                println!("✓ Set system_prompt to: {}", system_prompt);
+                println!("✓ Set system_prompt to: {system_prompt}");
                 changes += 1;
             }
 
             if let Some(users_prompt) = user_prompt {
                 config.set("user_prompt", Some(users_prompt.clone()))?;
-                println!("✓ Set user_prompt to: {}", users_prompt);
+                println!("✓ Set user_prompt to: {users_prompt}");
                 changes += 1;
             }
 
@@ -367,7 +367,7 @@ async fn ping_api(config: &Config) -> Result<()> {
     // Send the request
     let response = client
         .post(&endpoint)
-        .header("Authorization", format!("Bearer {}", api_token))
+        .header("Authorization", format!("Bearer {api_token}"))
         .header("Content-Type", "application/json")
         .json(&request)
         .send()
@@ -382,8 +382,8 @@ async fn ping_api(config: &Config) -> Result<()> {
         println!("{}", "✨ Configuration is working correctly.".green());
     } else {
         println!("{}", "❌ API connection failed:".red().bold());
-        println!("Status: {}", status);
-        println!("Error: {}", response_text);
+        println!("Status: {status}");
+        println!("Error: {response_text}");
     }
 
     Ok(())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -352,7 +352,7 @@ async fn ping_api(config: &Config) -> Result<()> {
 
     // Create a simple test request
     let client = reqwest::Client::new();
-    let endpoint = format!("{}/v1/chat/completions", api_base_url.trim_end_matches('/'));
+    let endpoint = format!("{}/chat/completions", api_base_url.trim_end_matches('/'));
 
     let request = serde_json::json!({
         "model": model,

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,7 +59,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             api_token: None,
-            api_base_url: Some("https://api.openai.com".to_string()),
+            api_base_url: Some("https://api.openai.com/v1".to_string()),
             model: Some("gpt-3.5-turbo".to_string()),
             system_prompt: Some(DEFAULT_SYSTEM_PROMPT.to_string()),
             user_prompt: Some(DEFAULT_USER_PROMPT.to_string()),
@@ -225,7 +225,7 @@ impl Config {
     pub fn get_api_base_url(&self) -> &str {
         self.api_base_url
             .as_deref()
-            .unwrap_or("https://api.openai.com")
+            .unwrap_or("https://api.openai.com/v1")
     }
 
     pub fn get_model(&self) -> &str {
@@ -255,7 +255,7 @@ mod tests {
         assert!(config.api_token.is_none());
         assert_eq!(
             config.api_base_url.as_deref(),
-            Some("https://api.openai.com")
+            Some("https://api.openai.com/v1")
         );
         assert_eq!(config.model.as_deref(), Some("gpt-3.5-turbo"));
         assert!(config.system_prompt.is_some());
@@ -359,7 +359,7 @@ mod tests {
         };
 
         assert!(empty_config.get_api_token().is_err());
-        assert_eq!(empty_config.get_api_base_url(), "https://api.openai.com");
+        assert_eq!(empty_config.get_api_base_url(), "https://api.openai.com/v1");
         assert_eq!(empty_config.get_model(), "gpt-3.5-turbo");
         assert_eq!(empty_config.get_system_prompt(), DEFAULT_SYSTEM_PROMPT);
         assert_eq!(empty_config.get_user_prompt(), DEFAULT_USER_PROMPT);

--- a/src/git.rs
+++ b/src/git.rs
@@ -38,7 +38,7 @@ pub fn push_changes() -> Result<()> {
         let error_message = String::from_utf8_lossy(&output.stderr).into_owned();
         eprintln!(
             "{}",
-            format!("⚠️  Failed to push changes: {}", error_message).red()
+            format!("⚠️  Failed to push changes: {error_message}").red()
         );
         anyhow::bail!("Git push failed");
     }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -51,7 +51,7 @@ pub async fn generate_commit_message(
     };
 
     // Construct the full API endpoint URL
-    let endpoint = format!("{}/v1/chat/completions", api_base_url.trim_end_matches('/'));
+    let endpoint = format!("{}/chat/completions", api_base_url.trim_end_matches('/'));
 
     // Send the request to the API
     let response = client
@@ -115,7 +115,7 @@ mod tests {
 
         // Set up the mock expectation
         Mock::given(method("POST"))
-            .and(path("/v1/chat/completions"))
+            .and(path("/chat/completions"))
             .and(header("Authorization", "Bearer test_token"))
             .and(header("Content-Type", "application/json"))
             .respond_with(ResponseTemplate::new(200).set_body_json(mock_response))
@@ -171,7 +171,7 @@ mod tests {
 
         // Set up the mock to return an error
         Mock::given(method("POST"))
-            .and(path("/v1/chat/completions"))
+            .and(path("/chat/completions"))
             .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
             .mount(&mock_server)
             .await;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -56,12 +56,12 @@ pub async fn generate_commit_message(
     // Send the request to the API
     let response = client
         .post(&endpoint)
-        .header("Authorization", format!("Bearer {}", api_token))
+        .header("Authorization", format!("Bearer {api_token}"))
         .header("Content-Type", "application/json")
         .json(&request)
         .send()
         .await
-        .context(format!("Failed to send request to API at {}", endpoint))?;
+        .context(format!("Failed to send request to API at {endpoint}"))?;
 
     // Parse the response
     let response_status = response.status();


### PR DESCRIPTION
Standardizes API base URL handling across the application by consistently including the /v1 path in the OpenAI API base URL. This ensures proper endpoint construction and prevents double-path issues when making API requests.

Updates all documentation examples and default configurations to reflect the correct API base URL format. Modifies endpoint construction in API calls to remove redundant /v1 path concatenation which would cause issues when using some APIs that don't have the "/v1" denominator